### PR TITLE
fix: Correct package installation from github or Bioconductor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _site/
 
 # Ignore R history file
 .Rhistory
+.radian_history

--- a/Correlation/ComplexHeatmap.qmd
+++ b/Correlation/ComplexHeatmap.qmd
@@ -22,7 +22,7 @@ The Complex Heatmap is an advanced data visualization tool primarily used to dis
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # Installing packages
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install.packages("ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("dendextend", quietly = TRUE)) {
   install.packages("dendextend")

--- a/Correlation/ComplexHeatmap.zh.qmd
+++ b/Correlation/ComplexHeatmap.zh.qmd
@@ -22,7 +22,7 @@ author:
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # 安装包
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install.packages("ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("dendextend", quietly = TRUE)) {
   install.packages("dendextend")

--- a/Correlation/Heatmap.qmd
+++ b/Correlation/Heatmap.qmd
@@ -39,7 +39,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("hrbrthemes", quietly = TRUE)) {
-  install.packages("hrbrthemes")
+  remotes::install_github("hrbrmstr/hrbrthemes")
 }
 if (!requireNamespace("dplyr", quietly = TRUE)) {
   install.packages("dplyr")

--- a/Correlation/Heatmap.qmd
+++ b/Correlation/Heatmap.qmd
@@ -25,7 +25,7 @@ Hierarchical clustering (dendrograms) on the top and left depict similarity rela
 
 -   Programming Language: R
 
--   Dependencies:`readr`, `ggplot2`, `hrbrthemes`, `dplyr`, `tidyr`, `viridis`, `tibble`, `htmlwidgets`, `RColorBrewer`, `plotly`, `devtools`, `d3heatmap`, `heatmaply`, `lattice`, `ComplexHeatmap`, `pheatmap`, `circlize`, `gridExtra`, `cowplot`
+-   Dependencies:`readr`, `ggplot2`, `hrbrthemes`, `dplyr`, `tidyr`, `viridis`, `tibble`, `htmlwidgets`, `RColorBrewer`, `plotly`, `remotes`, `d3heatmap`, `heatmaply`, `lattice`, `ComplexHeatmap`, `pheatmap`, `circlize`, `gridExtra`, `cowplot`
 
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # Installing necessary packages

--- a/Correlation/Heatmap.qmd
+++ b/Correlation/Heatmap.qmd
@@ -62,11 +62,8 @@ if (!requireNamespace("RColorBrewer", quietly = TRUE)) {
 if (!requireNamespace("plotly", quietly = TRUE)) {
   install.packages("plotly")
 }
-if (!requireNamespace("devtools", quietly = TRUE)) {
-  install.packages("devtools")
-}
 if (!requireNamespace("d3heatmap", quietly = TRUE)) {
-  devtools::install_github("talgalili/d3heatmap")
+  remotes::install_github("talgalili/d3heatmap")
 }
 if (!requireNamespace("heatmaply", quietly = TRUE)) {
   install.packages("heatmaply")
@@ -75,7 +72,7 @@ if (!requireNamespace("lattice", quietly = TRUE)) {
   install.packages("lattice")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  devtools::install_github("jokergoo/ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("pheatmap", quietly = TRUE)) {
   install.packages("pheatmap")

--- a/Correlation/UMAPplot.qmd
+++ b/Correlation/UMAPplot.qmd
@@ -40,7 +40,7 @@ if (!requireNamespace("Seurat", quietly = TRUE)) {
   install.packages("Seurat")
 }
 if (!requireNamespace("SeuratData", quietly = TRUE)) {
-  install_github('satijalab/seurat-data')
+  remotes::install_github('satijalab/seurat-data')
 }
 if (!requireNamespace("dplyr", quietly = TRUE)) {
   install.packages("dplyr")

--- a/Correlation/UMAPplot.zh.qmd
+++ b/Correlation/UMAPplot.zh.qmd
@@ -40,7 +40,7 @@ if (!requireNamespace("Seurat", quietly = TRUE)) {
   install.packages("Seurat")
 }
 if (!requireNamespace("SeuratData", quietly = TRUE)) {
-  install_github('satijalab/seurat-data')
+  remotes::install_github('satijalab/seurat-data')
 }
 if (!requireNamespace("dplyr", quietly = TRUE)) {
   install.packages("dplyr")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -168,7 +168,6 @@ Remotes:
     ricardo-bion/ggradar,
     hrbrmstr/streamgraph,
     yikeshu0611/fastStat,
-    ricardo-bion/ggradar,
     wch/extrafont,
     hrbrmstr/hrbrthemes,
     hrbrmstr/waffle,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -155,7 +155,6 @@ Remotes:
     ropensci-review-tools/babelquarto,
     hiplot/hiplotlib,
     theislab/destiny,
-    YuLab-SMU/clusterProfiler,
     junjunlab/scRNAtoolVis,
     MatthiasFutschik/Mfuzz,
     chrisamiller/fishplot,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -160,7 +160,6 @@ Remotes:
     MatthiasFutschik/Mfuzz,
     chrisamiller/fishplot,
     dongwei1220/flowerplot,
-    jokergoo/ComplexHeatmap,
     jbkunst/d3wordcloud,
     JohnCoene/echarts4r.assets,
     clauswilke/ggisoband,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -162,7 +162,6 @@ Remotes:
     jbkunst/d3wordcloud,
     JohnCoene/echarts4r.assets,
     clauswilke/ggisoband,
-    ShixiangWang/sigminer,
     jokergoo/gtrellis,
     hrbrmstr/ggalt,
     kevinblighe/EnhancedVolcano,

--- a/Distribution/BoxPlot.qmd
+++ b/Distribution/BoxPlot.qmd
@@ -33,7 +33,7 @@ if (!requireNamespace("dplyr", quietly = TRUE)) {
   install.packages("dplyr")
 }
 if (!requireNamespace("hrbrthemes", quietly = TRUE)) {
-  install.packages("hrbrthemes")
+  remotes::install_github("hrbrmstr/hrbrthemes")
 }
 if (!requireNamespace("viridis", quietly = TRUE)) {
   install.packages("viridis")

--- a/Distribution/Density.qmd
+++ b/Distribution/Density.qmd
@@ -37,7 +37,7 @@ if (!requireNamespace("ggExtra", quietly = TRUE)) {
   install.packages("ggExtra") 
 } 
 if (!requireNamespace("hrbrthemes", quietly = TRUE)) {
-  install.packages("hrbrthemes") 
+  remotes::install_github("hrbrmstr/hrbrthemes") 
 } 
 if (!requireNamespace("dplyr", quietly = TRUE)) {
   install.packages("dplyr") 

--- a/Distribution/Ridgeline.qmd
+++ b/Distribution/Ridgeline.qmd
@@ -33,7 +33,7 @@ if (!requireNamespace("ggridges", quietly = TRUE)) {
   install.packages("ggridges")
 }
 if (!requireNamespace("hrbrthemes", quietly = TRUE)) {
-  install.packages("hrbrthemes")
+  remotes::install_github("hrbrmstr/hrbrthemes")
 }
 if (!requireNamespace("viridis", quietly = TRUE)) {
   install.packages("viridis")

--- a/Distribution/ViolinPlot.qmd
+++ b/Distribution/ViolinPlot.qmd
@@ -43,7 +43,7 @@ if (!requireNamespace("forcats", quietly = TRUE)) {
   install.packages("forcats")
 }
 if (!requireNamespace("hrbrthemes", quietly = TRUE)) {
-  install.packages("hrbrthemes")
+  remotes::install_github("hrbrmstr/hrbrthemes")
 }
 if (!requireNamespace("viridis", quietly = TRUE)) {
   install.packages("viridis")

--- a/Hiplot/013-big-corrplot.qmd
+++ b/Hiplot/013-big-corrplot.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install.packages("ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 
 # Load packages

--- a/Hiplot/013-big-corrplot.zh.qmd
+++ b/Hiplot/013-big-corrplot.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install.packages("ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 
 # 加载包

--- a/Hiplot/025-complex-heatmap.qmd
+++ b/Hiplot/025-complex-heatmap.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install.packages("ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("circlize", quietly = TRUE)) {
   install.packages("circlize")

--- a/Hiplot/025-complex-heatmap.zh.qmd
+++ b/Hiplot/025-complex-heatmap.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install.packages("ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("circlize", quietly = TRUE)) {
   install.packages("circlize")

--- a/Hiplot/027-contour-matrix.qmd
+++ b/Hiplot/027-contour-matrix.qmd
@@ -38,7 +38,7 @@ if (!requireNamespace("reshape2", quietly = TRUE)) {
   install.packages("reshape2")
 }
 if (!requireNamespace("ggisoband", quietly = TRUE)) {
-  install.packages("ggisoband")
+  remotes::install_github("clauswilke/ggisoband")
 }
 if (!requireNamespace("cowplot", quietly = TRUE)) {
   install.packages("cowplot")

--- a/Hiplot/027-contour-matrix.zh.qmd
+++ b/Hiplot/027-contour-matrix.zh.qmd
@@ -38,7 +38,7 @@ if (!requireNamespace("reshape2", quietly = TRUE)) {
   install.packages("reshape2")
 }
 if (!requireNamespace("ggisoband", quietly = TRUE)) {
-  devtools::install_github("clauswilke/ggisoband")
+  remotes::install_github("clauswilke/ggisoband")
 }
 if (!requireNamespace("cowplot", quietly = TRUE)) {
   install.packages("cowplot")

--- a/Hiplot/028-contour-xy.qmd
+++ b/Hiplot/028-contour-xy.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("ggisoband", quietly = TRUE)) {
-  install.packages("ggisoband")
+  remotes::install_github("clauswilke/ggisoband")
 }
 
 # Load packages

--- a/Hiplot/028-contour-xy.zh.qmd
+++ b/Hiplot/028-contour-xy.zh.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("ggisoband", quietly = TRUE)) {
-  install.packages("ggisoband")
+  remotes::install_github("clauswilke/ggisoband")
 }
 
 # 加载包

--- a/Hiplot/029-cor-heatmap-simple.qmd
+++ b/Hiplot/029-cor-heatmap-simple.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("sigminer", quietly = TRUE)) {
-  install.packages("sigminer")
+  BiocManager::install("sigminer")
 }
 
 # Load packages

--- a/Hiplot/029-cor-heatmap-simple.zh.qmd
+++ b/Hiplot/029-cor-heatmap-simple.zh.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("sigminer", quietly = TRUE)) {
-  install.packages("sigminer")
+  BiocManager::install("sigminer")
 }
 
 # 加载包

--- a/Hiplot/035-custom-icon-scatter.qmd
+++ b/Hiplot/035-custom-icon-scatter.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("echarts4r", quietly = TRUE)) {
   install.packages("echarts4r")
 }
 if (!requireNamespace("echarts4r.assets", quietly = TRUE)) {
-  install_github("JohnCoene/echarts4r.assets")
+  remotes::install_github("JohnCoene/echarts4r.assets")
 }
 
 # Load packages

--- a/Hiplot/035-custom-icon-scatter.zh.qmd
+++ b/Hiplot/035-custom-icon-scatter.zh.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("echarts4r", quietly = TRUE)) {
   install.packages("echarts4r")
 }
 if (!requireNamespace("echarts4r.assets", quietly = TRUE)) {
-  install_github("JohnCoene/echarts4r.assets")
+  remotes::install_github("JohnCoene/echarts4r.assets")
 }
 
 # 加载包

--- a/Hiplot/036-d3-wordcloud.qmd
+++ b/Hiplot/036-d3-wordcloud.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("d3wordcloud", quietly = TRUE)) {
-  devtools::install_github("jbkunst/d3wordcloud")
+  remotes::install_github("jbkunst/d3wordcloud")
 }
 
 # Load packages

--- a/Hiplot/036-d3-wordcloud.zh.qmd
+++ b/Hiplot/036-d3-wordcloud.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("d3wordcloud", quietly = TRUE)) {
-  devtools::install_github("jbkunst/d3wordcloud")
+  remotes::install_github("jbkunst/d3wordcloud")
 }
 
 # 加载包

--- a/Hiplot/042-diffusion-map.qmd
+++ b/Hiplot/042-diffusion-map.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("destiny", quietly = TRUE)) {
-  install_github("theislab/destiny")
+  remots::install_github("theislab/destiny")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/042-diffusion-map.qmd
+++ b/Hiplot/042-diffusion-map.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("destiny", quietly = TRUE)) {
-  remots::install_github("theislab/destiny")
+  remotes::install_github("theislab/destiny")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/042-diffusion-map.zh.qmd
+++ b/Hiplot/042-diffusion-map.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("destiny", quietly = TRUE)) {
-  install_github("theislab/destiny")
+  remotes::install_github("theislab/destiny")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/044-diy-gsea.qmd
+++ b/Hiplot/044-diy-gsea.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("clusterProfiler", quietly = TRUE)) {
-  install_github("YuLab-SMU/clusterProfiler")
+  BiocManager::install("clusterProfiler")
 }
 
 # Load packages

--- a/Hiplot/044-diy-gsea.zh.qmd
+++ b/Hiplot/044-diy-gsea.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("clusterProfiler", quietly = TRUE)) {
-  install_github("YuLab-SMU/clusterProfiler")
+  BiocManager::install("clusterProfiler")
 }
 
 # 加载包

--- a/Hiplot/048-dumbbell.qmd
+++ b/Hiplot/048-dumbbell.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("ggalt", quietly = TRUE)) {
-  install.packages("ggalt")
+  remotes::install_github("hrbrmstr/ggalt")
 }
 
 # Load packages

--- a/Hiplot/048-dumbbell.zh.qmd
+++ b/Hiplot/048-dumbbell.zh.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("ggalt", quietly = TRUE)) {
-  install.packages("ggalt")
+  remotes::install_github("hrbrmstr/ggalt")
 }
 
 # 加载包

--- a/Hiplot/055-fishplot.qmd
+++ b/Hiplot/055-fishplot.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("fishplot", quietly = TRUE)) {
-  install_github("chrisamiller/fishplot")
+  remotes::install_github("chrisamiller/fishplot")
 }
 
 # Load packages

--- a/Hiplot/055-fishplot.zh.qmd
+++ b/Hiplot/055-fishplot.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("fishplot", quietly = TRUE)) {
-  install_github("chrisamiller/fishplot")
+  remotes::install_github("chrisamiller/fishplot")
 }
 
 # 加载包

--- a/Hiplot/056-flowerplot.qmd
+++ b/Hiplot/056-flowerplot.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("flowerplot", quietly = TRUE)) {
-  install_github("dongwei1220/flowerplot")
+  remotes::install_github("dongwei1220/flowerplot")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/056-flowerplot.zh.qmd
+++ b/Hiplot/056-flowerplot.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("flowerplot", quietly = TRUE)) {
-  install_github("dongwei1220/flowerplot")
+  remotes::install_github("dongwei1220/flowerplot")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/060-gene-density.qmd
+++ b/Hiplot/060-gene-density.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("circlize", quietly = TRUE)) {
   install.packages("circlize")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install_github("jokergoo/ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("gtrellis", quietly = TRUE)) {
   install_github("jokergoo/gtrellis")

--- a/Hiplot/060-gene-density.qmd
+++ b/Hiplot/060-gene-density.qmd
@@ -38,7 +38,7 @@ if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
   BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("gtrellis", quietly = TRUE)) {
-  install_github("jokergoo/gtrellis")
+  remotes::install_github("jokergoo/gtrellis")
 }
 if (!requireNamespace("tidyverse", quietly = TRUE)) {
   install.packages("tidyverse")

--- a/Hiplot/060-gene-density.zh.qmd
+++ b/Hiplot/060-gene-density.zh.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("circlize", quietly = TRUE)) {
   install.packages("circlize")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install_github("jokergoo/ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("gtrellis", quietly = TRUE)) {
   install_github("jokergoo/gtrellis")

--- a/Hiplot/060-gene-density.zh.qmd
+++ b/Hiplot/060-gene-density.zh.qmd
@@ -38,7 +38,7 @@ if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
   BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("gtrellis", quietly = TRUE)) {
-  install_github("jokergoo/gtrellis")
+  remotes::install_github("jokergoo/gtrellis")
 }
 if (!requireNamespace("tidyverse", quietly = TRUE)) {
   install.packages("tidyverse")

--- a/Hiplot/062-gene-trend.qmd
+++ b/Hiplot/062-gene-trend.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("Mfuzz", quietly = TRUE)) {
-  install_github("MatthiasFutschik/Mfuzz")
+  remotes::install_github("MatthiasFutschik/Mfuzz")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/062-gene-trend.zh.qmd
+++ b/Hiplot/062-gene-trend.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("Mfuzz", quietly = TRUE)) {
-  install_github("MatthiasFutschik/Mfuzz")
+  remotes::install_github("MatthiasFutschik/Mfuzz")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/080-grdotplot.qmd
+++ b/Hiplot/080-grdotplot.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("sigminer", quietly = TRUE)) {
-  install_github("ShixiangWang/sigminer")
+  remotes::install_github("ShixiangWang/sigminer")
 }
 if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")

--- a/Hiplot/080-grdotplot.zh.qmd
+++ b/Hiplot/080-grdotplot.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("sigminer", quietly = TRUE)) {
-  install_github("ShixiangWang/sigminer")
+  remotes::install_github("ShixiangWang/sigminer")
 }
 if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")

--- a/Hiplot/082-group-comparison.qmd
+++ b/Hiplot/082-group-comparison.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("sigminer", quietly = TRUE)) {
-  install_github("ShixiangWang/sigminer")
+  remotes::install_github("ShixiangWang/sigminer")
 }
 
 # Load packages

--- a/Hiplot/082-group-comparison.zh.qmd
+++ b/Hiplot/082-group-comparison.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("sigminer", quietly = TRUE)) {
-  install_github("ShixiangWang/sigminer")
+  remotes::install_github("ShixiangWang/sigminer")
 }
 
 # 加载包

--- a/Hiplot/083-group-dumbbell.qmd
+++ b/Hiplot/083-group-dumbbell.qmd
@@ -33,7 +33,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("ggalt", quietly = TRUE)) {
-  install.packages("ggalt")
+  remotes::install_github("hrbrmstr/ggalt")
 }
 
 # Load packages

--- a/Hiplot/083-group-dumbbell.zh.qmd
+++ b/Hiplot/083-group-dumbbell.zh.qmd
@@ -33,7 +33,7 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   install.packages("ggplot2")
 }
 if (!requireNamespace("ggalt", quietly = TRUE)) {
-  install.packages("ggalt")
+  remotes::install_github("hrbrmstr/ggalt")
 }
 
 # 加载包

--- a/Hiplot/086-heatmap.qmd
+++ b/Hiplot/086-heatmap.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install_github("jokergoo/ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("genefilter", quietly = TRUE)) {
   install.packages("genefilter")

--- a/Hiplot/086-heatmap.zh.qmd
+++ b/Hiplot/086-heatmap.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install_github("jokergoo/ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("genefilter", quietly = TRUE)) {
   install.packages("genefilter")

--- a/Hiplot/132-parallel-coordinate.qmd
+++ b/Hiplot/132-parallel-coordinate.qmd
@@ -33,7 +33,7 @@ if (!requireNamespace("GGally", quietly = TRUE)) {
   install.packages("GGally")
 }
 if (!requireNamespace("hrbrthemes", quietly = TRUE)) {
-  install.packages("hrbrthemes")
+  remotes::install_github("hrbrmstr/hrbrthemes")
 }
 if (!requireNamespace("viridis", quietly = TRUE)) {
   install.packages("viridis")

--- a/Hiplot/132-parallel-coordinate.zh.qmd
+++ b/Hiplot/132-parallel-coordinate.zh.qmd
@@ -33,7 +33,7 @@ if (!requireNamespace("GGally", quietly = TRUE)) {
   install.packages("GGally")
 }
 if (!requireNamespace("hrbrthemes", quietly = TRUE)) {
-  install.packages("hrbrthemes")
+  remotes::install_github("hrbrmstr/hrbrthemes")
 }
 if (!requireNamespace("viridis", quietly = TRUE)) {
   install.packages("viridis")

--- a/Hiplot/143-pseudo-enhanced-ma.qmd
+++ b/Hiplot/143-pseudo-enhanced-ma.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("EnhancedVolcano", quietly = TRUE)) {
-  install_github('kevinblighe/EnhancedVolcano')
+  remotes::install_github('kevinblighe/EnhancedVolcano')
 }
 
 # Load packages

--- a/Hiplot/143-pseudo-enhanced-ma.zh.qmd
+++ b/Hiplot/143-pseudo-enhanced-ma.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("EnhancedVolcano", quietly = TRUE)) {
-  install_github('kevinblighe/EnhancedVolcano')
+  remotes::install_github('kevinblighe/EnhancedVolcano')
 }
 
 # 加载包

--- a/Hiplot/150-radar.qmd
+++ b/Hiplot/150-radar.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("ggradar", quietly = TRUE)) {
-  install_github("ricardo-bion/ggradar", dependencies = TRUE)
+  remotes::install_github("ricardo-bion/ggradar", dependencies = TRUE)
 }
 if (!requireNamespace("dplyr", quietly = TRUE)) {
   install.packages("dplyr")

--- a/Hiplot/150-radar.zh.qmd
+++ b/Hiplot/150-radar.zh.qmd
@@ -32,7 +32,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("ggradar", quietly = TRUE)) {
-  install_github("ricardo-bion/ggradar", dependencies = TRUE)
+  remotes::install_github("ricardo-bion/ggradar", dependencies = TRUE)
 }
 if (!requireNamespace("dplyr", quietly = TRUE)) {
   install.packages("dplyr")

--- a/Hiplot/155-risk-plot.qmd
+++ b/Hiplot/155-risk-plot.qmd
@@ -33,7 +33,7 @@ if (!requireNamespace("survminer", quietly = TRUE)) {
   install.packages("survminer")
 }
 if (!requireNamespace("fastStat", quietly = TRUE)) {
-  install_github("yikeshu0611/fastStat")
+  remotes::install_github("yikeshu0611/fastStat")
 }
 if (!requireNamespace("cutoff", quietly = TRUE)) {
   install.packages("cutoff")

--- a/Hiplot/155-risk-plot.zh.qmd
+++ b/Hiplot/155-risk-plot.zh.qmd
@@ -33,7 +33,7 @@ if (!requireNamespace("survminer", quietly = TRUE)) {
   install.packages("survminer")
 }
 if (!requireNamespace("fastStat", quietly = TRUE)) {
-  install_github("yikeshu0611/fastStat")
+  remotes::install_github("yikeshu0611/fastStat")
 }
 if (!requireNamespace("cutoff", quietly = TRUE)) {
   install.packages("cutoff")

--- a/Hiplot/168-streamgraph.qmd
+++ b/Hiplot/168-streamgraph.qmd
@@ -30,7 +30,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("streamgraph", quietly = TRUE)) {
-  install_github("hrbrmstr/streamgraph")
+  remotes::install_github("hrbrmstr/streamgraph")
 }
 
 # Load packages

--- a/Hiplot/168-streamgraph.zh.qmd
+++ b/Hiplot/168-streamgraph.zh.qmd
@@ -30,7 +30,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("streamgraph", quietly = TRUE)) {
-  install_github("hrbrmstr/streamgraph")
+  remotes::install_github("hrbrmstr/streamgraph")
 }
 
 # 加载包

--- a/Hiplot/177-upset-plot.qmd
+++ b/Hiplot/177-upset-plot.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("VennDiagram", quietly = TRUE)) {
   install.packages("VennDiagram")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install_github("jokergoo/ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/177-upset-plot.zh.qmd
+++ b/Hiplot/177-upset-plot.zh.qmd
@@ -35,7 +35,7 @@ if (!requireNamespace("VennDiagram", quietly = TRUE)) {
   install.packages("VennDiagram")
 }
 if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-  install_github("jokergoo/ComplexHeatmap")
+  BiocManager::install("ComplexHeatmap")
 }
 if (!requireNamespace("ggplotify", quietly = TRUE)) {
   install.packages("ggplotify")

--- a/Hiplot/184-waffle.qmd
+++ b/Hiplot/184-waffle.qmd
@@ -30,7 +30,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("waffle", quietly = TRUE)) {
-  install.packages("waffle")
+  remotes::install_github("hrbrmstr/waffle")
 }
 
 # Load packages

--- a/Hiplot/184-waffle.zh.qmd
+++ b/Hiplot/184-waffle.zh.qmd
@@ -30,7 +30,7 @@ if (!requireNamespace("jsonlite", quietly = TRUE)) {
   install.packages("jsonlite")
 }
 if (!requireNamespace("waffle", quietly = TRUE)) {
-  install.packages("waffle")
+  remotes::install_github("hrbrmstr/waffle")
 }
 
 # 加载包

--- a/Omics/KeggPathwayPlot.qmd
+++ b/Omics/KeggPathwayPlot.qmd
@@ -25,7 +25,7 @@ The images and R packages are from the article by Luo et al. \[1\]
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # Installing packages
 if (!requireNamespace("pathview", quietly = TRUE)) {
-  install_github("datapplab/pathview")
+  remotes::install_github("datapplab/pathview")
 }
 if (!requireNamespace("dbplyr", quietly = TRUE)) {
   install.packages("dbplyr")

--- a/Omics/KeggPathwayPlot.zh.qmd
+++ b/Omics/KeggPathwayPlot.zh.qmd
@@ -25,7 +25,7 @@ author:
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # 安装包
 if (!requireNamespace("pathview", quietly = TRUE)) {
-  install_github("datapplab/pathview")
+  remotes::install_github("datapplab/pathview")
 }
 if (!requireNamespace("dbplyr", quietly = TRUE)) {
   install.packages("dbplyr")

--- a/Omics/MultiVolcanoPlot.qmd
+++ b/Omics/MultiVolcanoPlot.qmd
@@ -24,7 +24,7 @@ This Multiple Volcano Plot shows the differential gene expression patterns of mu
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # Installing necessary packages
 if (!requireNamespace("scRNAtoolVis", quietly = TRUE)) {
-  install_github('junjunlab/scRNAtoolVis')
+  remotes::install_github('junjunlab/scRNAtoolVis')
 }
 if (!requireNamespace("corrplot", quietly = TRUE)) {
   install.packages("corrplot")

--- a/Omics/MultiVolcanoPlot.zh.qmd
+++ b/Omics/MultiVolcanoPlot.zh.qmd
@@ -25,7 +25,7 @@ author:
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # 安装包
 if (!requireNamespace("scRNAtoolVis", quietly = TRUE)) {
-  install_github('junjunlab/scRNAtoolVis')
+  remotes::install_github('junjunlab/scRNAtoolVis')
 }
 if (!requireNamespace("corrplot", quietly = TRUE)) {
   install.packages("corrplot")

--- a/Omics/SyntenyBlocksPlot.qmd
+++ b/Omics/SyntenyBlocksPlot.qmd
@@ -23,7 +23,7 @@ Collinearity is widely used in the study of complex genomes. This tutorial, base
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # Installing packages
 if (!requireNamespace("UpSetR", quietly = TRUE)) {
-  devtools::install_github("ksamuk/syntR")
+  remotes::install_github("ksamuk/syntR")
 }
 
 # Load packages

--- a/Omics/SyntenyBlocksPlot.zh.qmd
+++ b/Omics/SyntenyBlocksPlot.zh.qmd
@@ -23,7 +23,7 @@ author:
 ```{r packages setup, message=FALSE, warning=FALSE, output=FALSE}
 # 安装包
 if (!requireNamespace("UpSetR", quietly = TRUE)) {
-  devtools::install_github("ksamuk/syntR")
+  remotes::install_github("ksamuk/syntR")
 }
 
 # 加载包


### PR DESCRIPTION
This PR does exactly what the title describes.

One point to clarify: for packages that are in Bioconductor but installed from GitHub, users will need to have `Rtools` installed to build the package. For packages that are only on GitHub, we can direct users to install them from GitHub.